### PR TITLE
fix broken pip install 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup
 from pip.req import parse_requirements
+from pip.download import PipSession
+
 
 long_desc = file("README.rst").read()
 
-install_reqs = parse_requirements('requirements.txt')
+install_reqs = parse_requirements('requirements.txt', session=PipSession())
 reqs = [str(ir.req) for ir in install_reqs]
 
 setup(


### PR DESCRIPTION
broken install from pip version 6.0
```
Collecting git+https://github.com/aqn/chatpy.git
  Cloning https://github.com/aqn/chatpy.git to /var/folders/c_/sc0nyb952yj21xk0whnl5wg80000gp/T/pip-c94eA8-build
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/var/folders/c_/sc0nyb952yj21xk0whnl5wg80000gp/T/pip-c94eA8-build/setup.py", line 7, in <module>
        reqs = [str(ir.req) for ir in install_reqs]
      File "/Users/hogeo/.virtualenvs/cht2/lib/python2.7/site-packages/pip/req/req_file.py", line 19, in parse_requirements
        "parse_requirements() missing 1 required keyword argument: "
    TypeError: parse_requirements() missing 1 required keyword argument: 'session'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

      File "<string>", line 20, in <module>

      File "/var/folders/c_/sc0nyb952yj21xk0whnl5wg80000gp/T/pip-c94eA8-build/setup.py", line 7, in <module>

        reqs = [str(ir.req) for ir in install_reqs]

      File "/Users/hogeo/.virtualenvs/cht2/lib/python2.7/site-packages/pip/req/req_file.py", line 19, in parse_requirements

        "parse_requirements() missing 1 required keyword argument: "

    TypeError: parse_requirements() missing 1 required keyword argument: 'session'

    ----------------------------------------
```