### PR TITLE
Update API to v2 endpoint

### DIFF
--- a/chatpy/api.py
+++ b/chatpy/api.py
@@ -12,7 +12,7 @@ class API(object):
 
     def __init__(self, auth_handler=None,
                  host='api.chatwork.com',
-                 cache=None, secure=True, api_root='/v1',
+                 cache=None, secure=True, api_root='/v2',
                  retry_count=0, retry_delay=0, retry_errors=None, timeout=60,
                  parser=None, compression=False):
         self.auth = auth_handler


### PR DESCRIPTION
エンドポイントのベースURIが変わります。
https://api.chatwork.com/v1　→　https://api.chatwork.com/v2

参考：https://help.chatwork.com/hc/ja/articles/115000019401